### PR TITLE
文章删除，文章对应显示，还有一些小漏洞

### DIFF
--- a/backend/app/controllers/Backend/ArticalController.php
+++ b/backend/app/controllers/Backend/ArticalController.php
@@ -3,6 +3,7 @@
 use View;
 use Controllers\BaseController;
 use Artical as ArticalModel;
+use Redirect;
 
 class ArticalController extends BaseController {
 
@@ -58,6 +59,10 @@ class ArticalController extends BaseController {
      */
     public function removeartical($id)
     {
+        $post = ArticalModel::findOrFail($id);
+        $post->delete();
 
+        return Redirect::route('BackendShowArtical')
+            ->with('success','文章删除成功');
     }
 }

--- a/backend/app/controllers/Backend/ArticalController.php
+++ b/backend/app/controllers/Backend/ArticalController.php
@@ -5,6 +5,7 @@ use Controllers\BaseController;
 use Artical as ArticalModel;
 use Redirect;
 use Auth;
+use App;
 
 
 class ArticalController extends BaseController {
@@ -66,7 +67,14 @@ class ArticalController extends BaseController {
      */
     public function removeartical($id)
     {
+        if(Auth::user()->permission == '作者'){
+            if(ArticalModel::findOrFail($id)->user !== Auth::user()->displayname){
+                return App::abort(404);
+            }
+        }
         $post = ArticalModel::findOrFail($id);
+        $post->delete();
+        $post = ArticalModel::findOrFail($id)->artical_catagory();
         $post->delete();
 
         return Redirect::route('BackendShowArtical')

--- a/backend/app/controllers/Backend/ArticalController.php
+++ b/backend/app/controllers/Backend/ArticalController.php
@@ -51,4 +51,13 @@ class ArticalController extends BaseController {
     {
     }
 
+    /**
+     * Backend Remove Artical
+     *
+     * @return Redirect
+     */
+    public function removeartical($id)
+    {
+
+    }
 }

--- a/backend/app/controllers/Backend/ArticalController.php
+++ b/backend/app/controllers/Backend/ArticalController.php
@@ -4,6 +4,8 @@ use View;
 use Controllers\BaseController;
 use Artical as ArticalModel;
 use Redirect;
+use Auth;
+
 
 class ArticalController extends BaseController {
 
@@ -14,10 +16,15 @@ class ArticalController extends BaseController {
      */
     public function showartical()
     {
+        if(Auth::user()->permission == '作者'){
+            $post_artical = ArticalModel::where('user','=',Auth::user()->displayname)->get();
+        }else{
+            $post_artical = ArticalModel::all();
+        }
         /**
          * take the information of artical
          */
-        foreach(ArticalModel::all() as $artical){
+        foreach($post_artical as $artical){
 
             $catagory = ArticalModel::find($artical['id'])->catagories->toArray();
             $articals[] = array(

--- a/backend/app/controllers/Backend/UserController.php
+++ b/backend/app/controllers/Backend/UserController.php
@@ -167,7 +167,8 @@ class UserController extends BaseController {
     public function newusers()
     {
         $validator = Validator::make(Input::all(),array(
-            'loginname' => 'required|min:4|max:20',
+            'loginname' => 'required|min:2|max:20',
+            'displayname' => 'required|min:2|max:15',
             'password' => 'required|min:6|max:20'
         ));
 
@@ -177,10 +178,8 @@ class UserController extends BaseController {
                 ->withErrors($validator);
         }
 
-        $loginname = Input::get('loginname');
-        $displayname = Input::get('displayname');
-        $password = Hash::make(Input::get('password'));
-        $permission = Input::get('permission');
+        extract(Input::all());
+
         if(UserModel::where('loginname','=',$loginname)->count()!== '0'){
 
             return Redirect::route('BackendShowUsers')

--- a/backend/app/controllers/Backend/UserController.php
+++ b/backend/app/controllers/Backend/UserController.php
@@ -84,19 +84,36 @@ class UserController extends BaseController {
         }
         $user = UserModel::findOrFail($id);
 
+        $input = Input::only('originpassword','password','displayname');
+        extract($input);
+
+        if($originpassword == '' &&  $password == ''){
+
+	         $validator = Validator::make(Input::all(),array(
+           		 'displayname' => 'required|min:2|max:20',
+                       	 ));
+             if($validator->fails()){
+             	 return Redirect::route('BackendShowArtical')
+             	     ->withInput()
+             	     ->withErrors($validator);
+             }
+
+             $user['displayname'] = $displayname;
+             $user->save();
+
+             return Redirect::route('BackendShowArtical')
+                 ->with('success','用户名修改成功');
+        }
+
         $validator = Validator::make(Input::all(),array(
-            'displayname' => 'required|min:4|max:20',
-            'password' => 'required|min:6|max:20'
-        ));
-        if($validator->fails())
-        {
+                'displayname' => 'required|min:2|max:20',
+                'password' => 'required|min:6|max:20'
+            ));
+        if($validator->fails()){
             return Redirect::route('BackendShowArtical')
                 ->withInput()
                 ->withErrors($validator);
         }
-
-        $input = Input::only('originpassword','password');
-        extract($input);
 
         if(!Hash::check($originpassword,$user['password']))
         {
@@ -106,12 +123,13 @@ class UserController extends BaseController {
         }
 
         $user['password'] = Hash::make($password);
+        $user['displayname'] = Input::get('displayname');
         $user->save();
 
         Auth::logout();
 
         return Redirect::route('BackendLogin')
-            ->with('success','密码更新成功，请重新登录');
+            ->with('success','用户信息更新成功，请重新登录');
 
     }
 

--- a/backend/app/controllers/Backend/UserController.php
+++ b/backend/app/controllers/Backend/UserController.php
@@ -78,10 +78,15 @@ class UserController extends BaseController {
      */
     public function updateuser($id)
     {
+        if($id !== Auth::user()->id){
+
+            return App::abort(404);
+        }
         $user = UserModel::findOrFail($id);
 
         $validator = Validator::make(Input::all(),array(
-            'password' => 'required|min:6|max:15'
+            'displayname' => 'required|min:4|max:20',
+            'password' => 'required|min:6|max:20'
         ));
         if($validator->fails())
         {

--- a/backend/app/models/Artical.php
+++ b/backend/app/models/Artical.php
@@ -9,7 +9,7 @@ class Artical extends Eloquent{
     /**
      * the attribute that allow to make a value together
      */
-    protected $fillable = array('title','see','content','frist');
+    protected $fillable = array('title','see','content','updown','user');
 
     /**
      * Atical_catagory field declaration

--- a/backend/app/models/Artical.php
+++ b/backend/app/models/Artical.php
@@ -12,7 +12,7 @@ class Artical extends Eloquent{
     protected $fillable = array('title','see','content','updown','user');
 
     /**
-     * Atical_catagory field declaration
+     * Catagory field declaration
      *
      * @return object;
      */
@@ -20,5 +20,14 @@ class Artical extends Eloquent{
     {
         return $this->belongsToMany('Catagory','artical_catagory',
             'artical_id','catagory_id');
+    }
+
+    /**
+     * Artical_catagory field declaration
+     *
+     * @return object;
+     */
+    public function artical_catagory(){
+        return $this->hasMany('Artical_catagory');
     }
 }

--- a/backend/app/routes.php
+++ b/backend/app/routes.php
@@ -46,10 +46,18 @@ Route::group(array('prefix' => 'backend','before' => 'auth'),function(){
         'uses' => 'Controllers\Backend\UserController@dologout'
     ));
 
-    Route::get('/artical',array(
-        'as' => 'BackendShowArtical',
-        'uses' => 'Controllers\Backend\ArticalController@showartical'
-    ));
+    Route::group(array('prefix' => 'artical','before' => ''),function(){
+
+        Route::get('/',array(
+           'as' => 'BackendShowArtical',
+           'uses' => 'Controllers\Backend\ArticalController@showartical'
+       ));
+
+        Route::get('/remove/{id}',array(
+            'as' => 'BackendRemoveArtical',
+            'uses' => 'Controllers\Backend\ArticalController@removeartical'
+        ));
+    });
 
     Route::group(array('prefix'=> 'edit','before'=> ''),function(){
 

--- a/backend/app/views/Backend/Artical/Artical_part.blade.php
+++ b/backend/app/views/Backend/Artical/Artical_part.blade.php
@@ -36,7 +36,7 @@
 		    @endforeach
 		</td>
 		<td>{{ $artical['created_at'] }}</td>
-		<td><a href=""><span class="glyphicon glyphicon-pencil"></span></a> | <a href=""><span class="glyphicon glyphicon-trash"></span></a> | <a href=""><span class="glyphicon glyphicon-thumbs-down"></span></a></td>
+		<td><a href=""><span class="glyphicon glyphicon-pencil"></span></a> | <a href="{{{ URL::route('BackendRemoveArtical',$artical['id'])}}}" onclick="return confirm('亲～～，你确定要删除么？')"><span class="glyphicon glyphicon-trash"></span></a> | <a href=""><span class="glyphicon glyphicon-thumbs-down"></span></a></td>
 	     </tr>
 	   @endforeach
 

--- a/backend/app/views/Backend/Frame.blade.php
+++ b/backend/app/views/Backend/Frame.blade.php
@@ -32,6 +32,6 @@ $("#member").select2({
    placeholder: "请分配权限"//选择框内提示信息
 });
 $('#editor').wysiwyg();
-@show
 </script>
+@show
 </html>


### PR DESCRIPTION
修复的漏洞：
      1.用户修改自己信息时的用户验证问题，验证不对抛出404；
      2.用户不能单独修改自己的displayname问题；

增加的新功能：
      1.editor权限的用户对应的文章显示；
      2.文章删除功能，editor权限用户需先经验证是否为自己的文章；
      （js 窗口提醒是否删除）；

存在的问题：
      权限验证的方式是固定的，即  if(Auth::user()->permission == '作者')，用户权限的处理方式不太对，我想先抛开这个问题不管，先把功能做出来。
