### PR TITLE
Fix substr

### DIFF
--- a/backend/app/config/freshman.php
+++ b/backend/app/config/freshman.php
@@ -13,5 +13,7 @@ return array(
     'nullChooseCatagoryId' => 0,
 
     'initRelevanceNumber' => 0,
-    'relevanceNumber' => 6
+    'relevanceNumber' => 6,
+
+    'substrLength' => 90
 );

--- a/backend/app/libraries/strFilter.php
+++ b/backend/app/libraries/strFilter.php
@@ -1,0 +1,21 @@
+<?php
+
+class strFilter {
+
+    /**
+     * 过滤HTML 并截取过滤后的字符串
+     *
+     * @param string $value
+     * @param int    $limit
+     * @param string $end
+     *
+     * @return string
+     */
+    public static function filterHtmlLimit($value, $limit = 60, $end = '...')
+    {
+        $value = strip_tags($value);
+        if(mb_strlen($value) <= $limit) return $value;
+
+        return mb_substr($value, 0, $limit, 'UTF-8').$end;
+    }
+}

--- a/backend/app/views/Front/List.blade.php
+++ b/backend/app/views/Front/List.blade.php
@@ -34,7 +34,7 @@
 							发布于：{{ $article['created_at'] }}&nbsp;&nbsp;&nbsp;&nbsp;来源：广东工业大学校团委数字中心
 						</span>
                         <p>
-                            {{ mb_substr($article['content'],1,90,"UTF-8") }}.....
+                            {{ mb_substr(strip_tags($article['content']),0,Config::get('freshman.substrLength'),"UTF-8") }}.....
                         </p>
 					</li>
                     @endforeach

--- a/backend/app/views/Front/List.blade.php
+++ b/backend/app/views/Front/List.blade.php
@@ -34,7 +34,7 @@
 							发布于：{{ $article['created_at'] }}&nbsp;&nbsp;&nbsp;&nbsp;来源：广东工业大学校团委数字中心
 						</span>
                         <p>
-                            {{ mb_substr(strip_tags($article['content']),0,Config::get('freshman.substrLength'),"UTF-8") }}.....
+                            {{ strFilter::filterHtmlLimit($article['content'],Config::get('freshman.substrLength')) }}
                         </p>
 					</li>
                     @endforeach

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -11,7 +11,8 @@
 			"app/models",
 			"app/database/migrations",
 			"app/database/seeds",
-			"app/tests/TestCase.php"
+			"app/tests/TestCase.php",
+            "app/libraries/strFilter.php"
 		]
 	},
 	"scripts": {


### PR DESCRIPTION
Ps:

```
       string strip_tags ( string $str [, string $allowable_tags ] )
```

This function tries to return a string with all NULL bytes, HTML and PHP tags stripped from a given str. It uses the same tag stripping state machine as the fgetss() function.

see http://php.net/manual/en/function.strip-tags.php

mb_substr() see http://cn2.php.net/manual/en/function.mb-substr.php
